### PR TITLE
Auto reload client when server changes

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,125 +1,14 @@
-# recommended profile includes all checked rules from this page: http://eslint.org/docs/rules
-extends: 'eslint:recommended'
+extends:
+  - standard
+
+globals:
+  process: true
+  globalConf: true
 
 env:
   es6: true
   node: true
 
 rules:
-  # Possible Errors
-  no-extra-parens: error
-  # no-prototype-builtins: error
-  no-unsafe-finally: error
-  valid-jsdoc: [warn, requireReturn: false]
-
-  # Best Practices
-  block-scoped-var: error
-  consistent-return: error
-  curly: [error, multi-line, consistent]
-  default-case: error
-  dot-location: [error, property]
-  dot-notation: error
-  eqeqeq: [error, allow-null]
-  no-alert: error
-  no-caller: error
-  no-div-regex: error
-  no-else-return: error
-  no-empty-function: error
-  no-eval: error
-  no-extend-native: error
-  no-extra-bind: error
-  no-extra-label: error
-  no-fallthrough: error
-  no-invalid-this: error
-  no-implied-eval: error
-  no-iterator: error
-  no-labels: error
-  no-lone-blocks: error
-  no-native-reassign: error
-  no-new: error
-  no-new-wrappers: error
-  no-param-reassign: error
-  no-proto: error
-  no-return-assign: error
-  no-self-compare: error
-  no-sequences: error
-  no-throw-literal: error
-  no-unmodified-loop-condition: error
-  no-unused-expressions: error
-  no-useless-call: error
-  no-useless-concat: error
-  no-useless-escape: error
-  no-void: error
-  no-warning-comments: [warn, {location: anywhere, terms: [TODO, TODOC, FIXME]}]
-  no-with: error
-  radix: error
-
-  # Variables
-  no-catch-shadow: error
-  no-shadow: error
+  # non-standard rules
   no-undefined: off
-
-  # Node.js and CommonJS
-  callback-return: error
-  handle-callback-err: error
-  no-mixed-requires: error
-  no-path-concat: error
-
-  # stylistic
-  array-bracket-spacing: [error, never]
-  block-spacing: [error, always]
-  brace-style: [error, 1tbs]
-  camelcase: error
-  comma-spacing: error
-  comma-style: [error, last]
-  computed-property-spacing: [error, never]
-  eol-last: error
-  indent: [error, 2]
-  jsx-quotes: error
-  key-spacing: error
-  keyword-spacing: error
-  max-len: [error, 120]
-  new-cap: error
-  new-parens: error
-  no-array-constructor: error
-  no-bitwise: error
-  no-lonely-if: error
-  no-mixed-spaces-and-tabs: error
-  no-new-object: error
-  no-spaced-func: error
-  no-trailing-spaces: error
-  no-unneeded-ternary: error
-  no-whitespace-before-property: error
-  object-curly-spacing: error
-  operator-linebreak: [error, before]
-  quote-props: [error, as-needed]
-  quotes: [error, single]
-  semi: [error, never]
-  space-before-blocks: error
-  space-before-function-paren: [error, never]
-  space-in-parens: error
-  space-unary-ops: error
-  spaced-comment: error
-
-  # ECMAScript 6
-  arrow-body-style: [error, as-needed]
-  arrow-parens: [error, as-needed]
-  arrow-spacing: error
-  no-class-assign: error
-  no-confusing-arrow: [error, allowParens: true]
-  no-const-assign: error
-  no-dupe-class-members: error
-  no-duplicate-imports: error
-  no-this-before-super: error
-  no-useless-computed-key: error
-  no-useless-constructor: error
-  no-var: error
-  object-shorthand: error
-  prefer-arrow-callback: error
-  prefer-const: error
-  prefer-rest-params: error
-  prefer-spread: error
-  prefer-template: error
-  require-yield: error
-  # spread-spacing: [error, never]
-  template-curly-spacing: [error, never]

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -57,7 +57,7 @@ rules:
   # Variables
   no-catch-shadow: error
   no-shadow: error
-  no-undefined: error
+  no-undefined: off
 
   # Node.js and CommonJS
   callback-return: error

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ module.exports = [{
 
 ## Changelog
 
+### 3.1.0
+- Automatically reloads exposed APIs when remote server has changed, and mark previous APIs as deprecated
+- Use [standard.js](https://standardjs.com/) lint configuration
+
 ### 3.0.0
 - [*Breaking change*] Groups are now used as sub-objects of client.
 - Use CRC32 checksum to validate that remote server is compatible

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ module.exports = [{
 ### 3.1.0
 - Automatically reloads exposed APIs when remote server has changed, and mark previous APIs as deprecated
 - Use [standard.js](https://standardjs.com/) lint configuration
+- Don't fail if an API resolves or returns `undefined` value.
 
 ### 3.0.0
 - [*Breaking change*] Groups are now used as sub-objects of client.

--- a/lib/client.js
+++ b/lib/client.js
@@ -66,7 +66,6 @@ class Client {
         }
         // reserved keyword that aren't defined must be undefined (thenable false-positive)
         if (reserved.includes(propKey)) {
-          /* eslint no-undefined: 0 */
           return undefined
         }
         // creates a function that will get exposed API from remote server
@@ -74,7 +73,6 @@ class Client {
           get(_1, subPropKey) {
             // reserved keyword that aren't defined must be undefined (thenable false-positive)
             if (reserved.includes(subPropKey)) {
-              /* eslint no-undefined: 0 */
               return undefined
             }
             return (...args) => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,13 +4,12 @@ const {registerFromServer, registerLocal} = require('./register')
 const reserved = ['then', 'catch', 'finally']
 
 class Client {
-
   /**
    * @summary Service version.
    * @description For remote clients, undefined until the first call. Then, set to server's version
    * @member {String}
    */
-  get version() {
+  get version () {
     return this.internalVersion
   }
 
@@ -38,7 +37,7 @@ class Client {
    * a Promise resolved with exposed APIs (an object with functions that returns promises)
    * @param {Object} [opts.groupOpts]     per-group configuration. might contain a properties named after group
    */
-  constructor(opts = {}) {
+  constructor (opts = {}) {
     this.initialized = false
     this.options = Object.assign({
       logger: getLogger({name: 'mini-client'})
@@ -59,7 +58,7 @@ class Client {
     }
 
     const traps = {
-      get(target, propKey) {
+      get (target, propKey) {
         // version and init are the only prop callable while proxy is still active
         if (['version', 'internalVersion', 'init', 'initialized', 'options'].includes(propKey)) {
           return target[propKey]
@@ -70,7 +69,7 @@ class Client {
         }
         // creates a function that will get exposed API from remote server
         return new Proxy(() => { /* esling no-empty: 0 */ }, {
-          get(_1, subPropKey) {
+          get (_1, subPropKey) {
             // reserved keyword that aren't defined must be undefined (thenable false-positive)
             if (reserved.includes(subPropKey)) {
               return undefined
@@ -94,7 +93,7 @@ class Client {
                 })
             }
           },
-          apply(_1, _2, args) {
+          apply (_1, _2, args) {
             logger.debug(`during ${propKey}, connect to ${remote} to get exposed apis`)
             return registerFromServer(target, remote, logger)
               .then(() => {
@@ -120,7 +119,7 @@ class Client {
    * `init()` async methods. But for remote clients, this is a noop, and can be skipped.
    * @returns {Promise} resolved when client is initialized, without any arguments
    */
-  init() {
+  init () {
     if (this.initialized || this.options.remote) return Promise.resolve()
     const {logger} = this.options
     return Promise.resolve()

--- a/lib/register.js
+++ b/lib/register.js
@@ -147,7 +147,12 @@ exports.registerLocal = (context, opts, logger) => {
                 // forces input/output serialization and deserialization to have consistent result with remote client
                 try {
                   return apis[id](...JSON.parse(JSON.stringify(args)))
-                    .then(result => JSON.parse(JSON.stringify(result)))
+                    .then(result => {
+                      if (result !== undefined) {
+                        return JSON.parse(JSON.stringify(result))
+                      }
+                      return result
+                    })
                 } catch (exc) {
                   // bubble any synchronous problem (not returning promise, serialization issue...)
                   exc.message = `Error while calling API ${id}: ${exc.message}`

--- a/lib/register.js
+++ b/lib/register.js
@@ -3,12 +3,13 @@ const crc32 = require('crc32')
 const joi = require('joi')
 const {
   arrayToObj,
+  checksumHeader,
   extractGroups,
   extractValidate,
   getParamNames,
   isApi,
   validateParams
-}= require('mini-service-utils')
+} = require('mini-service-utils')
 
 /**
  * Internal API registration functions
@@ -16,21 +17,21 @@ const {
  */
 
 /**
- * Created operation should be regrouped according to their own group
- *
- * Registering operations could occur:
+ * @private
+ * @summary Created operation should be regrouped according to their own group
+ * @description Registering operations could occur:
  * - on root context when operation belongs to group named afer the service
  * - on group subobject when operation belongs to a different group
  *
- * @param {Object} context root context in which operations will be created
- * @param {String} group group name currently processed
- * @param {Object} opts options describing local/remote service
- * @param {String} opts.name of current service
+ * @param {Object} context       root context in which operations will be created
+ * @param {String} group        group name currently processed
+ * @param {Object} exposed      options describing local/remote service
+ * @param {String} exposed.name of current service
  * @returns {Object} in which operations could be registered as functions
  */
-const computeGroup = (context, group, opts) => {
+const computeGroup = (context, group, exposed) => {
   // use group if it's not the service name
-  if (group !== opts.name) {
+  if (group !== exposed.name) {
     // creates group if not present yet
     if (!(group in context)) {
       context[group] = {}
@@ -40,6 +41,42 @@ const computeGroup = (context, group, opts) => {
   return context
 }
 
+/**
+ * @private
+ * @summary Checksum validation: fail if not compatible
+ * @description Extract actual checksum from Http response header, and compare it to expected
+ * If they differ:
+ * - mark existing exposed API as deprecated. They will trigger an error
+ * - fetch new exposed API, and creates new groups and function
+ * - invoke the current API to fullfill invoked API
+ *
+ * @param {Response} response Http response
+ * @param {String} checksum   expected checksum
+ * @param {String} client     expected server version (for error message)
+ * TODO
+ */
+const checkCompatibility = (response, checksum, client, group, id, args) => {
+  const {options: {remote, logger}, exposed, internalVersion: previousVersion} = client
+  // checksum validation: fail if not compatible
+  const actualChecksum = response.headers[checksumHeader]
+  // TODO no checksum found
+  if (actualChecksum === checksum) {
+    return Promise.resolve(response.body)
+  }
+  logger.info('Remote server change detected')
+  // server has changed, marks existing methods as deprecated
+  exposed.apis.forEach(({group, id}) => {
+    computeGroup(client, group, exposed)[id] = () =>
+      Promise.reject(new Error(`Remote server isn't compatible with current client (expects ${previousVersion})`))
+    logger.debug(`API ${id} from ${group} deprecated`)
+  })
+  // then register once more
+  return exports.registerFromServer(client, remote, logger)
+    .then(() =>
+      // now invokes the current API once more.
+      computeGroup(client, group, client.exposed)[id](...args)
+    )
+}
 
 /**
  * @summary Ask a given server for APIs to register into the given context (remote client)
@@ -49,17 +86,20 @@ const computeGroup = (context, group, opts) => {
  * @param {Bunyan} logger   logger used to report init
  * @returns {Promise}       resolve without argument when all apis have been exposed into context
  */
-exports.registerFromServer = (client, url, logger) =>
-  request({
+exports.registerFromServer = (client, url, logger) => {
+  logger.info(`Fetch exposed API from ${url}`)
+  return request({
     method: 'GET',
     uri: `${url}/api/exposed`,
     json: true
   }).then(exposed => {
     // update client version
     client.internalVersion = `${exposed.name}@${exposed.version}`
+    client.exposed = exposed
     const checksum = crc32(JSON.stringify(exposed.apis))
     // add one method to client per exposed api
     exposed.apis.forEach(({group, path, id, params}) => {
+      logger.debug(`API ${id} from ${group} loaded (${client.internalVersion})`)
       const method = params.length ? 'POST' : 'GET'
       computeGroup(client, group, exposed)[id] = (...args) =>
         request({
@@ -68,23 +108,20 @@ exports.registerFromServer = (client, url, logger) =>
           body: arrayToObj(args, params),
           json: true,
           resolveWithFullResponse: true
-        }).then(response => {
-          // checksum validation: fail if not compatible
-          const actualChecksum = response.headers['x-service-crc']
-          if (actualChecksum !== checksum) {
-            throw new Error(`Remote server isn't compatible with current client (expects ${client.internalVersion})`)
-          }
+        }).then(response =>
+          checkCompatibility(response, checksum, client, group, id, args)
+        ).then(result => {
           logger.debug({api: {group, id}}, 'api sucessfully invoked')
-          return response.body
+          return result
         }).catch(err => {
           if (err.statusCode === 400 && err.error) {
             throw new Error(err.error.message)
           }
           throw err
         })
-      logger.debug(`API ${id} from ${group} loaded`)
     })
   })
+}
 
 /**
  * @summary Register given APIs using into the given context (local client)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-client",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Mini client for mini services: Micro services done simply",
   "author": "feugy <damien.feugas@gmail.com>",
   "license": "MIT",
@@ -12,7 +12,7 @@
   "main": "./lib/client.js",
   "scripts": {
     "doc": "jsdoc -c jsdoc.json",
-    "lint": "eslint .",
+    "lint": "eslint . --fix",
     "nsp": "nsp check",
     "prepush": "npm run nsp & npm test",
     "submit-coverage": "cat coverage/lcov.info | coveralls -v",
@@ -33,6 +33,11 @@
     "coveralls": "~2.13.1",
     "docdash": "~0.4.0",
     "eslint": "~4.7.2",
+    "eslint-config-standard": "~10.2.1",
+    "eslint-plugin-import": "~2.7.0",
+    "eslint-plugin-node": "~5.2.0",
+    "eslint-plugin-promise": "~3.5.0",
+    "eslint-plugin-standard": "~3.0.1",
     "hapi": "~16.6.0",
     "husky": "~0.14.3",
     "jsdoc": "~3.5.5",

--- a/test/fixtures/modified-server.js
+++ b/test/fixtures/modified-server.js
@@ -1,5 +1,4 @@
 const {Server} = require('hapi')
-const Boom = require('boom')
 const Joi = require('joi')
 const crc32 = require('crc32')
 const {checksumHeader, getLogger, validateParams} = require('mini-service-utils')
@@ -21,16 +20,14 @@ module.exports = opts => {
   }, opts)
 
   const apis = [
-    {group: 'sample', id: 'ping', params: [], path: '/api/sample/ping'},
-    {group: 'sample-service', id: 'noGroup', params: [], path: '/api/sample-service/no-group'},
+    {group: 'modified', id: 'ping', params: [], path: '/api/modified/ping'},
     {group: 'sample', id: 'greeting', params: ['name'], path: '/api/sample/greeting'},
-    {group: 'sample', id: 'failing', params: [], path: '/api/sample/failing'},
     {group: 'sample', id: 'getUndefined', params: [], path: '/api/sample/get-undefined'}
   ]
 
   const checksum = crc32(JSON.stringify(apis))
 
-  const {port, logger, groupOpts} = options
+  const {port, logger} = options
   logger.debug({port}, 'Configure server')
 
   const server = new Server()
@@ -38,14 +35,7 @@ module.exports = opts => {
 
   server.route({
     method: 'GET',
-    path: '/api/sample/ping',
-    config: {validate: {}},
-    handler: (req, reply) => reply({time: new Date()}).header(checksumHeader, checksum)
-  })
-
-  server.route({
-    method: 'GET',
-    path: '/api/sample-service/no-group',
+    path: '/api/modified/ping',
     config: {validate: {}},
     handler: (req, reply) => reply({time: new Date()}).header(checksumHeader, checksum)
   })
@@ -60,15 +50,8 @@ module.exports = opts => {
       }
     },
     handler: (req, reply) =>
-      reply(`Hello ${req.payload.name}${groupOpts.greetings || ''} !`)
+      reply(`Hello dear ${req.payload.name} !`)
         .header(checksumHeader, checksum)
-  })
-
-  server.route({
-    method: 'GET',
-    path: '/api/sample/failing',
-    config: {validate: {}},
-    handler: (req, reply) => reply(Boom.create(599, 'something went really bad'))
   })
 
   server.route({
@@ -82,7 +65,7 @@ module.exports = opts => {
     path: '/api/exposed',
     handler: (req, reply) => reply({
       name: 'sample-service',
-      version: '1.0.0',
+      version: '2.0.0',
       apis
     })
   })

--- a/test/fixtures/sample-server.js
+++ b/test/fixtures/sample-server.js
@@ -24,7 +24,8 @@ module.exports = opts => {
     {group: 'sample', id: 'ping', params: [], path: '/api/sample/ping'},
     {group: 'sample-service', id: 'pingOutOfSync', params: [], path: '/api/sample/ping-out-of-sync'},
     {group: 'sample', id: 'greeting', params: ['name'], path: '/api/sample/greeting'},
-    {group: 'sample', id: 'failing', params: [], path: '/api/sample/failing'}
+    {group: 'sample', id: 'failing', params: [], path: '/api/sample/failing'},
+    {group: 'sample', id: 'getUndefined', params: [], path: '/api/sample/get-undefined'}
   ]
 
   const checksum = crc32(JSON.stringify(apis))
@@ -68,6 +69,12 @@ module.exports = opts => {
     path: '/api/sample/failing',
     config: {validate: {}},
     handler: (req, reply) => reply(Boom.create(599, 'something went really bad'))
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/api/sample/get-undefined',
+    handler: (req, reply) => reply(undefined).header(checksumHeader, checksum)
   })
 
   server.route({

--- a/test/fixtures/sample.js
+++ b/test/fixtures/sample.js
@@ -48,6 +48,14 @@ module.exports = (opts = {}) => {
      */
     notCompliant() {
       return 10
+    },
+
+    /**
+     * API that returns undefined
+     * @returns {Promise<undefined>} promise resolved with nothing
+     */
+    getUndefined() {
+      return Promise.resolve(undefined)
     }
   }
 

--- a/test/fixtures/sample.js
+++ b/test/fixtures/sample.js
@@ -6,14 +6,13 @@ const Joi = require('joi')
  * @returns {Promise} promise - resolve with an object containing exposed APIs
  */
 module.exports = (opts = {}) => {
-
   const apis = {
     /**
      * Respond to ping
      * @returns {Promise} promise - resolved with an object containing:
      * @returns {Date} promise.time - ping current time
      */
-    ping() {
+    ping () {
       return Promise.resolve({time: new Date()})
     },
 
@@ -22,7 +21,7 @@ module.exports = (opts = {}) => {
      * @param {String} name - person to greet
      * @returns {Promise} promise - resolved with a greeting string message
      */
-    greeting(name) {
+    greeting (name) {
       return Promise.resolve(`Hello ${name}${opts.greetings || ''} !`)
     },
 
@@ -30,7 +29,7 @@ module.exports = (opts = {}) => {
      * Failing API to test rejection handling
      * @returns {Promise} promise - always rejected
      */
-    failing() {
+    failing () {
       return Promise.reject(new Error('something went really bad'))
     },
 
@@ -38,7 +37,7 @@ module.exports = (opts = {}) => {
      * API that synchronously fails when executing
      * @throws always an error
      */
-    errored() {
+    errored () {
       throw new Error('errored API')
     },
 
@@ -46,7 +45,7 @@ module.exports = (opts = {}) => {
      * API that doesn't return a promise
      * @returns {Number} a magic number
      */
-    notCompliant() {
+    notCompliant () {
       return 10
     },
 
@@ -54,7 +53,7 @@ module.exports = (opts = {}) => {
      * API that returns undefined
      * @returns {Promise<undefined>} promise resolved with nothing
      */
-    getUndefined() {
+    getUndefined () {
       return Promise.resolve(undefined)
     }
   }

--- a/test/local-group-init.js
+++ b/test/local-group-init.js
@@ -8,7 +8,6 @@ const lab = exports.lab = Lab.script()
 const {describe, it, before, beforeEach, after} = lab
 
 describe('local clients with an ordered list of groups', () => {
-
   before(utils.shutdownLogger)
 
   after(utils.restoreLogger)

--- a/test/local-no-group.js
+++ b/test/local-no-group.js
@@ -16,7 +16,7 @@ describe('local client without API group', () => {
 
   before(() =>
     utils.shutdownLogger()
-      .then(() =>  context.client.init())
+      .then(() => context.client.init())
   )
 
   after(utils.restoreLogger)

--- a/test/local.js
+++ b/test/local.js
@@ -7,7 +7,6 @@ const lab = exports.lab = Lab.script()
 const {describe, it, before, after} = lab
 
 describe('mini-client', () => {
-
   it('should be initialized multiple times', () => {
     const instance = getClient({name: 'multiple', version: '1.0.0', init: () => Promise.resolve({})})
     return instance.init()
@@ -27,7 +26,6 @@ describe('local client with API group', () => {
       sample: {greetings: ' nice to meet you'}
     }
   })}
-
 
   before(() =>
     utils.shutdownLogger()

--- a/test/remote-edge-cases.js
+++ b/test/remote-edge-cases.js
@@ -124,10 +124,10 @@ describe('remote client without server', () => {
   it('should process operation not in groups', () =>
     startServer()
       .then(server =>
-        remote.pingOutOfSync() // not exposed by server
+        remote.noGroup()
           .then(res => {
             server.stop()
-            assert.fail(res, '', 'unexpected result')
+            assert(moment(res).isValid())
           }, err => {
             server.stop()
             assert(err instanceof Error)

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -70,6 +70,13 @@ exports.declareTests = (it, context, withGroups = true) => {
         assert(err.message.includes('must contain at most'))
       })
   )
+
+  it('should handle undefined result', () =>
+    invoke(context, 'getUndefined', withGroups)()
+      .then(res => {
+        assert(res === undefined)
+      })
+  )
 }
 
 // Test when client is local

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -9,7 +9,6 @@ const invoke = (context, operation, withGroups = true) => {
 }
 
 exports.declareTests = (it, context, withGroups = true) => {
-
   it('should respond to ping', () =>
     invoke(context, 'ping', withGroups)()
       .then(result => {


### PR DESCRIPTION
When mini-client detects a server change (thanks to CRC32 checksum comparisons), it depreciate the existing APIs, fetches the new exposed ones, and try to process current call.

Don't fail if an API resolves or returns undefined value.

Uses Standard.js lint configuration